### PR TITLE
Added prevailing visibility operator to METAR/SPECI cases. Fixed CNL and NIL TAF cases

### DIFF
--- a/Amd78-2018/metar/BGBW-282350Z.xml
+++ b/Amd78-2018/metar/BGBW-282350Z.xml
@@ -44,6 +44,7 @@ TAC: SPECI BGBW 282350Z AUTO /////KT 9999NDV BKN190/// M03/M12 Q1023-->
       <iwxxm:visibility>
         <iwxxm:AerodromeHorizontalVisibility>
           <iwxxm:prevailingVisibility uom="m">10000</iwxxm:prevailingVisibility>
+          <iwxxm:prevailingVisibilityOperator>ABOVE</iwxxm:prevailingVisibilityOperator>
         </iwxxm:AerodromeHorizontalVisibility>
       </iwxxm:visibility>
       <iwxxm:cloud>

--- a/Amd78-2018/metar/BGGH-282350Z.xml
+++ b/Amd78-2018/metar/BGGH-282350Z.xml
@@ -50,6 +50,7 @@ TAC: SPECI BGGH 282350Z 100P50KT 9999 SCT110 BKN130 M07/M11 Q1021-->
       <iwxxm:visibility>
         <iwxxm:AerodromeHorizontalVisibility>
           <iwxxm:prevailingVisibility uom="m">10000</iwxxm:prevailingVisibility>
+          <iwxxm:prevailingVisibilityOperator>ABOVE</iwxxm:prevailingVisibilityOperator>
         </iwxxm:AerodromeHorizontalVisibility>
       </iwxxm:visibility>
       <iwxxm:cloud>

--- a/Amd78-2018/metar/BGJN-282350Z.xml
+++ b/Amd78-2018/metar/BGJN-282350Z.xml
@@ -51,6 +51,7 @@ TAC: SPECI BGJN 282350Z 14035GP50KT 9999 SCT180 M19/M26 Q1024-->
       <iwxxm:visibility>
         <iwxxm:AerodromeHorizontalVisibility>
           <iwxxm:prevailingVisibility uom="m">10000</iwxxm:prevailingVisibility>
+          <iwxxm:prevailingVisibilityOperator>ABOVE</iwxxm:prevailingVisibilityOperator>
         </iwxxm:AerodromeHorizontalVisibility>
       </iwxxm:visibility>
       <iwxxm:cloud>

--- a/Amd78-2018/metar/BIAR-290000Z.xml
+++ b/Amd78-2018/metar/BIAR-290000Z.xml
@@ -51,6 +51,7 @@ TAC: METAR BIAR 290000Z 33003KT 280V010 9999 OVC032 04/M00 Q////-->
       <iwxxm:visibility>
         <iwxxm:AerodromeHorizontalVisibility>
           <iwxxm:prevailingVisibility uom="m">10000</iwxxm:prevailingVisibility>
+          <iwxxm:prevailingVisibilityOperator>ABOVE</iwxxm:prevailingVisibilityOperator>
         </iwxxm:AerodromeHorizontalVisibility>
       </iwxxm:visibility>
       <iwxxm:cloud>

--- a/Amd78-2018/metar/EDDP-290020Z.xml
+++ b/Amd78-2018/metar/EDDP-290020Z.xml
@@ -51,6 +51,7 @@ TAC: SPECI EDDP 290020Z 21008KT 180V240 9999 FEW028 BKN060 07/06 Q0996 BECMG 250
       <iwxxm:visibility>
         <iwxxm:AerodromeHorizontalVisibility>
           <iwxxm:prevailingVisibility uom="m">10000</iwxxm:prevailingVisibility>
+          <iwxxm:prevailingVisibilityOperator>ABOVE</iwxxm:prevailingVisibilityOperator>
         </iwxxm:AerodromeHorizontalVisibility>
       </iwxxm:visibility>
       <iwxxm:cloud>

--- a/Amd78-2018/metar/EETN-290020Z.xml
+++ b/Amd78-2018/metar/EETN-290020Z.xml
@@ -49,6 +49,7 @@ TAC: SPECI EETN 290020Z 24006KT 9999 FEW019 M05/M07 Q1015 R08/0///95 NOSIG-->
       <iwxxm:visibility>
         <iwxxm:AerodromeHorizontalVisibility>
           <iwxxm:prevailingVisibility uom="m">10000</iwxxm:prevailingVisibility>
+          <iwxxm:prevailingVisibilityOperator>ABOVE</iwxxm:prevailingVisibilityOperator>
         </iwxxm:AerodromeHorizontalVisibility>
       </iwxxm:visibility>
       <iwxxm:cloud>

--- a/Amd78-2018/metar/EFHK-290020Z.xml
+++ b/Amd78-2018/metar/EFHK-290020Z.xml
@@ -49,6 +49,7 @@ TAC: SPECI EFHK 290020Z 32003KT 9999 R04R/0800N R15/P1500N R22L/P1500N R04L/P150
       <iwxxm:visibility>
         <iwxxm:AerodromeHorizontalVisibility>
           <iwxxm:prevailingVisibility uom="m">10000</iwxxm:prevailingVisibility>
+          <iwxxm:prevailingVisibilityOperator>ABOVE</iwxxm:prevailingVisibilityOperator>
         </iwxxm:AerodromeHorizontalVisibility>
       </iwxxm:visibility>
       <iwxxm:rvr>

--- a/Amd78-2018/metar/EKRK-290020Z.xml
+++ b/Amd78-2018/metar/EKRK-290020Z.xml
@@ -50,6 +50,7 @@ TAC: SPECI EKRK 290020Z AUTO 09017G27KT 9999NDV OVC100/// 00/M03 Q1004 R99/21006
       <iwxxm:visibility>
         <iwxxm:AerodromeHorizontalVisibility>
           <iwxxm:prevailingVisibility uom="m">10000</iwxxm:prevailingVisibility>
+          <iwxxm:prevailingVisibilityOperator>ABOVE</iwxxm:prevailingVisibilityOperator>
         </iwxxm:AerodromeHorizontalVisibility>
       </iwxxm:visibility>
       <iwxxm:cloud>

--- a/Amd78-2018/metar/NTAA-290000Z.xml
+++ b/Amd78-2018/metar/NTAA-290000Z.xml
@@ -49,6 +49,7 @@ TAC: METAR NTAA 290000Z 25005KT 9999 FEW026 SCT043 32/24 Q1012 WS R04 NOSIG-->
       <iwxxm:visibility>
         <iwxxm:AerodromeHorizontalVisibility>
           <iwxxm:prevailingVisibility uom="m">10000</iwxxm:prevailingVisibility>
+          <iwxxm:prevailingVisibilityOperator>ABOVE</iwxxm:prevailingVisibilityOperator>
         </iwxxm:AerodromeHorizontalVisibility>
       </iwxxm:visibility>
       <iwxxm:cloud>

--- a/Amd78-2018/metar/NTAA-290015Z.xml
+++ b/Amd78-2018/metar/NTAA-290015Z.xml
@@ -49,6 +49,7 @@ TAC: SPECI NTAA 290015Z 25004KT 9999 FEW026 SCT043 32/24 Q1012 WS ALL RWY NOSIG-
       <iwxxm:visibility>
         <iwxxm:AerodromeHorizontalVisibility>
           <iwxxm:prevailingVisibility uom="m">10000</iwxxm:prevailingVisibility>
+          <iwxxm:prevailingVisibilityOperator>ABOVE</iwxxm:prevailingVisibilityOperator>
         </iwxxm:AerodromeHorizontalVisibility>
       </iwxxm:visibility>
       <iwxxm:cloud>

--- a/Amd78-2018/metar/UBBB-290000Z.xml
+++ b/Amd78-2018/metar/UBBB-290000Z.xml
@@ -49,6 +49,7 @@ TAC: METAR UBBB 290000Z 35009KT 9999 SCT004 OVC200 07/06 Q1014 R88/CLRD// NOSIG-
       <iwxxm:visibility>
         <iwxxm:AerodromeHorizontalVisibility>
           <iwxxm:prevailingVisibility uom="m">10000</iwxxm:prevailingVisibility>
+          <iwxxm:prevailingVisibilityOperator>ABOVE</iwxxm:prevailingVisibilityOperator>
         </iwxxm:AerodromeHorizontalVisibility>
       </iwxxm:visibility>
       <iwxxm:cloud>

--- a/Amd78-2018/metar/UIBB-290000Z.xml
+++ b/Amd78-2018/metar/UIBB-290000Z.xml
@@ -51,6 +51,7 @@ TAC: METAR UIBB 290000Z 25005MPS 220V280 9999 SCT033 M01/M07 Q1018 R30/811050 NO
       <iwxxm:visibility>
         <iwxxm:AerodromeHorizontalVisibility>
           <iwxxm:prevailingVisibility uom="m">10000</iwxxm:prevailingVisibility>
+          <iwxxm:prevailingVisibilityOperator>ABOVE</iwxxm:prevailingVisibilityOperator>
         </iwxxm:AerodromeHorizontalVisibility>
       </iwxxm:visibility>
       <iwxxm:cloud>

--- a/Amd78-2018/taf/DAOY-131100Z.xml
+++ b/Amd78-2018/taf/DAOY-131100Z.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0"?>
-<iwxxm:TAF xmlns:aixm="http://www.aixm.aero/schema/5.1.1" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:iwxxm="http://icao.int/iwxxm/3.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" gml:id="uuid.8bc387de-f49e-44d3-ad99-f9bc278babac" isNilReport="true" permissibleUsage="OPERATIONAL" reportStatus="NORMAL" translatedBulletinID="TTAACCCC291927" translatedBulletinReceptionTime="2018-10-29T19:27:56Z" translationCentreDesignator="KWNO" translationCentreName="NCEP Central Operations" translationTime="2018-10-29T19:27:56Z" xsi:schemaLocation="http://icao.int/iwxxm/3.0 http://schemas.wmo.int/iwxxm/3.0.0RC2/iwxxm.xsd">
+<iwxxm:TAF xmlns:aixm="http://www.aixm.aero/schema/5.1.1" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:iwxxm="http://icao.int/iwxxm/3.0"
+  xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" gml:id="uuid.8bc387de-f49e-44d3-ad99-f9bc278babac"
+  permissibleUsage="OPERATIONAL" reportStatus="NORMAL" translatedBulletinID="TTAACCCC291927" 
+  translatedBulletinReceptionTime="2018-10-29T19:27:56Z" translationCentreDesignator="KWNO" 
+  translationCentreName="NCEP Central Operations" translationTime="2018-10-29T19:27:56Z"
+  xsi:schemaLocation="http://icao.int/iwxxm/3.0 http://schemas.wmo.int/iwxxm/3.0.0RC2/iwxxm.xsd">
   <!--
 This example of Terminal Aerodrome Forecast TAC to XML translation should not be considered authorative
 but is provided for your review and consideration. Comments and feedback are welcomed.

--- a/Amd78-2018/taf/EHLW-131400Z.xml
+++ b/Amd78-2018/taf/EHLW-131400Z.xml
@@ -2,12 +2,12 @@
 <!--but is provided for your review and consideration. Comments and feedback are welcomed.-->
 <!--                                                                                      -->
 <!--TAC: TAF EHLW 131400Z 1309/1321 CNL-->
-<iwxxm:TAF gml:id="uuid.28ab9c43-7cbd-40f4-96c3-573e5c720601" permissibleUsage="OPERATIONAL" status="CANCELLATION"
+<iwxxm:TAF gml:id="uuid.28ab9c43-7cbd-40f4-96c3-573e5c720601" permissibleUsage="OPERATIONAL" reportStatus="NORMAL" isCancelReport="true"
   translatedBulletinID="FTNL31KWBC131442" translatedBulletinReceptionTime="2018-08-13T14:00:37" translationCentreDesignator="KWNO"
   translationCentreName="NCEP Central Operations" translationTime="2018-08-15T18:28:24Z" xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
   xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:iwxxm="http://icao.int/iwxxm/3.0" xmlns:xlink="http://www.w3.org/1999/xlink"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://icao.int/iwxxm/3.0 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd">
+  xsi:schemaLocation="http://icao.int/iwxxm/3.0 http://schemas.wmo.int/iwxxm/3.0.0RC2/iwxxm.xsd">
   <iwxxm:issueTime>
     <gml:TimeInstant gml:id="uuid.f1d08699-1f28-4515-aa55-3dc68cacc931">
       <gml:timePosition>2018-08-13T14:00:00Z</gml:timePosition>
@@ -24,18 +24,10 @@
       </aixm:timeSlice>
     </aixm:AirportHeliport>
   </iwxxm:aerodrome>
-  <iwxxm:validTime>
+  <iwxxm:cancelledReportValidPeriod>
     <gml:TimePeriod gml:id="uuid.c1bb0ada-39ac-4951-9d18-a9d5c478a0a6">
       <gml:beginPosition>2018-08-13T14:00:00Z</gml:beginPosition>
       <gml:endPosition>2018-08-13T21:00:00Z</gml:endPosition>
     </gml:TimePeriod>
-  </iwxxm:validTime>
-  <iwxxm:baseForecast nilReason="http://codes.wmo.int/common/nil/missing"/>
-  <iwxxm:previousReportAerodrome xlink:href="#uuid.32880375-78e6-4efb-8313-4c3679702527"/>
-  <iwxxm:previousReportValidPeriod>
-    <gml:TimePeriod gml:id="uuid.e9e729e7-052c-4f4f-ac97-fb4b503a317b">
-      <gml:beginPosition>2018-08-13T09:00:00Z</gml:beginPosition>
-      <gml:endPosition>2018-08-13T21:00:00Z</gml:endPosition>
-    </gml:TimePeriod>
-  </iwxxm:previousReportValidPeriod>
+  </iwxxm:cancelledReportValidPeriod>
 </iwxxm:TAF>


### PR DESCRIPTION
'9999' implies >10km prevailing visibility in METAR/SPECI so prevailingVisibilityOperator 'ABOVE' was added to those instances.

Cancelled and NIL'd TAF cases now pass schematron validation.