### PR TITLE
Removed deprecated GML type

### DIFF
--- a/Amd77-2016/airmet/airmet-A6-1a-TS.xml
+++ b/Amd77-2016/airmet/airmet-A6-1a-TS.xml
@@ -109,7 +109,7 @@ OBS N OF S50 TOP ABV FL100 STNR WKN
                           <aixm:lowerLimitReference>STD</aixm:lowerLimitReference>
                           <aixm:horizontalProjection>
                             <aixm:Surface gml:id="obs-sfc" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                              <gml:polygonPatches>
+                              <gml:patches>
                                 <gml:PolygonPatch>
                                   <gml:exterior>
                                     <gml:LinearRing>
@@ -118,7 +118,7 @@ OBS N OF S50 TOP ABV FL100 STNR WKN
                                     </gml:LinearRing>
                                   </gml:exterior>
                                 </gml:PolygonPatch>
-                              </gml:polygonPatches>
+                              </gml:patches>
                             </aixm:Surface>
                           </aixm:horizontalProjection>
                         </aixm:AirspaceVolume>

--- a/Amd77-2016/sigmet/sigmet-A6-1a-TS.xml
+++ b/Amd77-2016/sigmet/sigmet-A6-1a-TS.xml
@@ -112,7 +112,7 @@ YUDD SHANLON FIR/UIR OBSC TS FCST S OF N54 AND E OF W012 TOP FL390 MOV E 20KT WK
                           <aixm:upperLimitReference>STD</aixm:upperLimitReference>
                           <aixm:horizontalProjection>
                             <aixm:Surface gml:id="sfc1" uomLabels="deg deg" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                              <gml:polygonPatches>
+                              <gml:patches>
                                 <gml:PolygonPatch>
                                   <gml:exterior>
                                     <gml:LinearRing>
@@ -123,7 +123,7 @@ YUDD SHANLON FIR/UIR OBSC TS FCST S OF N54 AND E OF W012 TOP FL390 MOV E 20KT WK
                                     </gml:LinearRing>
                                   </gml:exterior>
                                 </gml:PolygonPatch>
-                              </gml:polygonPatches>
+                              </gml:patches>
                             </aixm:Surface>
                           </aixm:horizontalProjection>
                         </aixm:AirspaceVolume>

--- a/Amd77-2016/sigmet/sigmet-A6-2-TC.xml
+++ b/Amd77-2016/sigmet/sigmet-A6-2-TC.xml
@@ -117,7 +117,7 @@ FCST AT 2200Z TC CENTRE PSN N2740 W07345
                               <aixm:upperLimitReference>STD</aixm:upperLimitReference>
                               <aixm:horizontalProjection>
                                   <aixm:Surface gml:id="tc-obs-N2706-sfc" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                                      <gml:polygonPatches>
+                                      <gml:patches>
                                           <gml:PolygonPatch>
                                               <gml:exterior>
                                                   <gml:Ring>
@@ -134,7 +134,7 @@ FCST AT 2200Z TC CENTRE PSN N2740 W07345
                                                   </gml:Ring>
                                               </gml:exterior>
                                           </gml:PolygonPatch>
-                                      </gml:polygonPatches>
+                                      </gml:patches>
                                   </aixm:Surface>
                               </aixm:horizontalProjection>
                           </aixm:AirspaceVolume>
@@ -176,7 +176,7 @@ FCST AT 2200Z TC CENTRE PSN N2740 W07345
                                 <aixm:AirspaceVolume gml:id="as2">
                                     <aixm:horizontalProjection>
                                         <aixm:Surface gml:id="sfc002" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                                            <gml:polygonPatches>
+                                            <gml:patches>
                                                 <gml:PolygonPatch>
                                                     <gml:exterior>
                                                         <gml:Ring>
@@ -193,7 +193,7 @@ FCST AT 2200Z TC CENTRE PSN N2740 W07345
                                                         </gml:Ring>
                                                     </gml:exterior>
                                                 </gml:PolygonPatch>
-                                            </gml:polygonPatches>
+                                            </gml:patches>
                                         </aixm:Surface>
                                     </aixm:horizontalProjection>
                                 </aixm:AirspaceVolume>

--- a/Amd77-2016/sigmet/sigmet-VA-EGGX.xml
+++ b/Amd77-2016/sigmet/sigmet-VA-EGGX.xml
@@ -106,7 +106,7 @@ EGGX SHANWICK OCEANIC FIR VA ERUPTION MT HEKLA PSN N6359 W01940 VA CLD OBS AT 16
                               axisLabels="Lat Lon"
                               srsDimension="2"
                               srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                              <gml:polygonPatches>
+                              <gml:patches>
                                 <gml:PolygonPatch>
                                   <gml:exterior>
                                     <gml:LinearRing>
@@ -120,7 +120,7 @@ EGGX SHANWICK OCEANIC FIR VA ERUPTION MT HEKLA PSN N6359 W01940 VA CLD OBS AT 16
                                     </gml:LinearRing>
                                   </gml:exterior>
                                 </gml:PolygonPatch>
-                              </gml:polygonPatches>
+                              </gml:patches>
                             </aixm:Surface>
                           </aixm:horizontalProjection>
                         </aixm:AirspaceVolume>
@@ -153,7 +153,7 @@ EGGX SHANWICK OCEANIC FIR VA ERUPTION MT HEKLA PSN N6359 W01940 VA CLD OBS AT 16
                                 <aixm:AirspaceVolume gml:id="av-va-fcst-position-EGGX-YYYYMM25T22Z">
                                     <aixm:horizontalProjection>
                                         <aixm:Surface gml:id="polygon-va-fcst-position-EGGX-YYYYMM25T22Z" uomLabels="deg deg" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                                            <gml:polygonPatches>
+                                            <gml:patches>
                                                 <gml:PolygonPatch>
                                                     <gml:exterior>
                                                         <gml:LinearRing>
@@ -167,7 +167,7 @@ EGGX SHANWICK OCEANIC FIR VA ERUPTION MT HEKLA PSN N6359 W01940 VA CLD OBS AT 16
                                                         </gml:LinearRing>
                                                     </gml:exterior>
                                                 </gml:PolygonPatch>
-                                            </gml:polygonPatches>
+                                            </gml:patches>
                                         </aixm:Surface>
                                     </aixm:horizontalProjection>
                                 </aixm:AirspaceVolume>

--- a/Amd77-2016/sigmet/sigmet-multi-location.xml
+++ b/Amd77-2016/sigmet/sigmet-multi-location.xml
@@ -106,7 +106,7 @@ FCST 1800Z VA CLD APRX N4200 E02145 – N4145 E02215 – N4100 E02215 - N4130 E0
                   <aixm:horizontalProjection>
                     <aixm:Surface gml:id="polygon-va-obs-position-YUDD-YYYYMM10T12Z1" uomLabels="deg deg" axisLabels="Lat Lon" srsDimension="2"
                       srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                      <gml:polygonPatches>
+                      <gml:patches>
                         <gml:PolygonPatch>
                           <gml:exterior>
                             <gml:LinearRing>
@@ -114,7 +114,7 @@ FCST 1800Z VA CLD APRX N4200 E02145 – N4145 E02215 – N4100 E02215 - N4130 E0
                             </gml:LinearRing>
                           </gml:exterior>
                         </gml:PolygonPatch>
-                      </gml:polygonPatches>
+                      </gml:patches>
                     </aixm:Surface>
                   </aixm:horizontalProjection>
                 </aixm:AirspaceVolume>
@@ -134,7 +134,7 @@ FCST 1800Z VA CLD APRX N4200 E02145 – N4145 E02215 – N4100 E02215 - N4130 E0
                   <aixm:horizontalProjection>
                     <aixm:Surface gml:id="polygon-va-obs-position-YUDD-YYYYMM10T12Z2" uomLabels="deg deg" axisLabels="Lat Lon" srsDimension="2"
                       srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                      <gml:polygonPatches>
+                      <gml:patches>
                         <gml:PolygonPatch>
                           <gml:exterior>
                             <gml:LinearRing>
@@ -142,7 +142,7 @@ FCST 1800Z VA CLD APRX N4200 E02145 – N4145 E02215 – N4100 E02215 - N4130 E0
                             </gml:LinearRing>
                           </gml:exterior>
                         </gml:PolygonPatch>
-                      </gml:polygonPatches>
+                      </gml:patches>
                     </aixm:Surface>
                   </aixm:horizontalProjection>
                 </aixm:AirspaceVolume>
@@ -175,7 +175,7 @@ FCST 1800Z VA CLD APRX N4200 E02145 – N4145 E02215 – N4100 E02215 - N4130 E0
                 <aixm:AirspaceVolume gml:id="av-va-fcst-position-YUDD-YYYYMM10T22Z1">
                   <aixm:horizontalProjection>
                     <aixm:Surface gml:id="polygon-va-fcst-position-YUDD-YYYYMM10T22Z1" uomLabels="deg deg" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                      <gml:polygonPatches>
+                      <gml:patches>
                         <gml:PolygonPatch>
                           <gml:exterior>
                             <gml:LinearRing>
@@ -183,7 +183,7 @@ FCST 1800Z VA CLD APRX N4200 E02145 – N4145 E02215 – N4100 E02215 - N4130 E0
                             </gml:LinearRing>
                           </gml:exterior>
                         </gml:PolygonPatch>
-                      </gml:polygonPatches>
+                      </gml:patches>
                     </aixm:Surface>
                   </aixm:horizontalProjection>
                 </aixm:AirspaceVolume>
@@ -197,7 +197,7 @@ FCST 1800Z VA CLD APRX N4200 E02145 – N4145 E02215 – N4100 E02215 - N4130 E0
                 <aixm:AirspaceVolume gml:id="av-va-fcst-position-YUDD-YYYYMM10T22Z2">
                   <aixm:horizontalProjection>
                     <aixm:Surface gml:id="polygon-va-fcst-position-YUDD-YYYYMM10T22Z2" uomLabels="deg deg" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                      <gml:polygonPatches>
+                      <gml:patches>
                         <gml:PolygonPatch>
                           <gml:exterior>
                             <gml:LinearRing>
@@ -205,7 +205,7 @@ FCST 1800Z VA CLD APRX N4200 E02145 – N4145 E02215 – N4100 E02215 - N4130 E0
                             </gml:LinearRing>
                           </gml:exterior>
                         </gml:PolygonPatch>
-                      </gml:polygonPatches>
+                      </gml:patches>
                     </aixm:Surface>
                   </aixm:horizontalProjection>
                 </aixm:AirspaceVolume>

--- a/Amd77-2016/sigmet/sigmet-point.xml
+++ b/Amd77-2016/sigmet/sigmet-point.xml
@@ -88,7 +88,7 @@ NZZC NEW ZEALAND FIR SEV TURB OBS AT 2123Z S4123 E17315 FL045 STNR NC=
        <aixm:lowerLimitReference>STD</aixm:lowerLimitReference>
        <aixm:horizontalProjection>
         <aixm:Surface gml:id="analysis-OBS-surface-0" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-         <gml:polygonPatches>
+         <gml:patches>
           <gml:PolygonPatch>
            <gml:exterior>
             <gml:Ring>
@@ -105,7 +105,7 @@ NZZC NEW ZEALAND FIR SEV TURB OBS AT 2123Z S4123 E17315 FL045 STNR NC=
             </gml:Ring>
            </gml:exterior>
           </gml:PolygonPatch>
-         </gml:polygonPatches>
+         </gml:patches>
         </aixm:Surface>
        </aixm:horizontalProjection>
       </aixm:AirspaceVolume>

--- a/Amd78-2018/sigmet/sigmet-multiple-TC.xml
+++ b/Amd78-2018/sigmet/sigmet-multiple-TC.xml
@@ -100,7 +100,7 @@
                             <aixm:upperLimitReference>STD</aixm:upperLimitReference>
                             <aixm:horizontalProjection>
                                 <aixm:Surface gml:id="uuid.62695824-f234-4618-b459-90bb795cde9a" srsDimension="2" axisLabels="Lat Long" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                                    <gml:polygonPatches>
+                                    <gml:patches>
                                         <gml:PolygonPatch>
                                             <gml:exterior>
                                                 <gml:Ring>
@@ -117,7 +117,7 @@
                                                 </gml:Ring>
                                             </gml:exterior>
                                         </gml:PolygonPatch>
-                                    </gml:polygonPatches>
+                                    </gml:patches>
                                 </aixm:Surface>
                             </aixm:horizontalProjection>
                         </aixm:AirspaceVolume>
@@ -149,7 +149,7 @@
                             <aixm:upperLimitReference>STD</aixm:upperLimitReference>
                             <aixm:horizontalProjection>
                                 <aixm:Surface gml:id="uuid.674c55ba-0dfe-400c-93b0-6be72d9290e1" srsDimension="2" axisLabels="Lat Long" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                                    <gml:polygonPatches>
+                                    <gml:patches>
                                         <gml:PolygonPatch>
                                             <gml:exterior>
                                                 <gml:Ring>
@@ -166,7 +166,7 @@
                                                 </gml:Ring>
                                             </gml:exterior>
                                         </gml:PolygonPatch>
-                                    </gml:polygonPatches>
+                                    </gml:patches>
                                 </aixm:Surface>
                             </aixm:horizontalProjection>
                         </aixm:AirspaceVolume>

--- a/Amd78-2018/tropical-cyclone-advisory/FKNT23KNHC-1501.xml
+++ b/Amd78-2018/tropical-cyclone-advisory/FKNT23KNHC-1501.xml
@@ -42,7 +42,7 @@
           <aixm:maximumLimit uom="FL">350</aixm:maximumLimit>
           <aixm:horizontalProjection>
             <aixm:Surface gml:id="uuid.aaede9f4-b233-4013-9f71-b92d1367ac8a" axisLabels="Lat Long" srsName="http://www.opengis.net/def/crs/EPSG/0/4326" srsDimension="2">
-              <gml:polygonPatches>
+              <gml:patches>
                 <gml:PolygonPatch>
                   <gml:exterior>
                     <gml:LinearRing>
@@ -50,7 +50,7 @@
                     </gml:LinearRing>
                   </gml:exterior>
                 </gml:PolygonPatch>
-              </gml:polygonPatches>
+              </gml:patches>
             </aixm:Surface>
           </aixm:horizontalProjection>
         </aixm:AirspaceVolume>
@@ -63,7 +63,7 @@
           <aixm:lowerLimitReference>STD</aixm:lowerLimitReference>
           <aixm:horizontalProjection>
             <aixm:Surface gml:id="uuid.b6f21a5a-e46e-4c09-9854-066ecea4f24d" axisLabels="Lat Long" srsName="http://www.opengis.net/def/crs/EPSG/0/4326" srsDimension="2">
-              <gml:polygonPatches>
+              <gml:patches>
                 <gml:PolygonPatch>
                   <gml:exterior>
                     <gml:LinearRing>
@@ -71,7 +71,7 @@
                     </gml:LinearRing>
                   </gml:exterior>
                 </gml:PolygonPatch>
-              </gml:polygonPatches>
+              </gml:patches>
             </aixm:Surface>
           </aixm:horizontalProjection>
         </aixm:AirspaceVolume>

--- a/Amd78-2018/tropical-cyclone-advisory/FKPQ30RJTD-1800.xml
+++ b/Amd78-2018/tropical-cyclone-advisory/FKPQ30RJTD-1800.xml
@@ -42,7 +42,7 @@
           <aixm:maximumLimit nilReason="unknown" xsi:nil="true"/>
           <aixm:horizontalProjection>
             <aixm:Surface gml:id="uuid.35ed25e0-ff05-4009-a599-fe8349247f8e" axisLabels="Lat Long" srsName="http://www.opengis.net/def/crs/EPSG/0/4326" srsDimension="2">
-              <polygonPatches xmlns="http://www.opengis.net/gml/3.2">
+              <patches xmlns="http://www.opengis.net/gml/3.2">
                 <PolygonPatch>
                   <exterior>
                     <Ring>
@@ -59,7 +59,7 @@
                     </Ring>
                   </exterior>
                 </PolygonPatch>
-              </polygonPatches>
+              </patches>
             </aixm:Surface>
           </aixm:horizontalProjection>
         </aixm:AirspaceVolume>

--- a/Amd79-80/tropical-cyclone-advisory/FKNT23KNHC-1501.xml
+++ b/Amd79-80/tropical-cyclone-advisory/FKNT23KNHC-1501.xml
@@ -42,7 +42,7 @@
           <aixm:maximumLimit uom="FL">350</aixm:maximumLimit>
           <aixm:horizontalProjection>
             <aixm:Surface gml:id="uuid.0e1dc9a2-254a-4d17-987b-262a3019769d" axisLabels="Lat Long" srsName="http://www.opengis.net/def/crs/EPSG/0/4326" srsDimension="2">
-              <gml:polygonPatches>
+              <gml:patches>
                 <gml:PolygonPatch>
                   <gml:exterior>
                     <gml:LinearRing>
@@ -50,7 +50,7 @@
                     </gml:LinearRing>
                   </gml:exterior>
                 </gml:PolygonPatch>
-              </gml:polygonPatches>
+              </gml:patches>
             </aixm:Surface>
           </aixm:horizontalProjection>
         </aixm:AirspaceVolume>
@@ -63,7 +63,7 @@
           <aixm:lowerLimitReference>STD</aixm:lowerLimitReference>
           <aixm:horizontalProjection>
             <aixm:Surface gml:id="uuid.61ec8d9c-1b7e-4695-9729-474e5e2b03c3" axisLabels="Lat Long" srsName="http://www.opengis.net/def/crs/EPSG/0/4326" srsDimension="2">
-              <gml:polygonPatches>
+              <gml:patches>
                 <gml:PolygonPatch>
                   <gml:exterior>
                     <gml:LinearRing>
@@ -71,7 +71,7 @@
                     </gml:LinearRing>
                   </gml:exterior>
                 </gml:PolygonPatch>
-              </gml:polygonPatches>
+              </gml:patches>
             </aixm:Surface>
           </aixm:horizontalProjection>
         </aixm:AirspaceVolume>

--- a/Amd79-80/tropical-cyclone-advisory/FKPQ30RJTD-1800.xml
+++ b/Amd79-80/tropical-cyclone-advisory/FKPQ30RJTD-1800.xml
@@ -42,7 +42,7 @@
           <aixm:maximumLimit nilReason="unknown" xsi:nil="true"/>
           <aixm:horizontalProjection>
             <aixm:Surface gml:id="uuid.2bc8ed6e-0b54-4046-acfa-3fd6645f7e3c" axisLabels="Lat Long" srsName="http://www.opengis.net/def/crs/EPSG/0/4326" srsDimension="2">
-              <polygonPatches xmlns="http://www.opengis.net/gml/3.2">
+              <patches xmlns="http://www.opengis.net/gml/3.2">
                 <PolygonPatch>
                   <exterior>
                     <Ring>
@@ -59,7 +59,7 @@
                     </Ring>
                   </exterior>
                 </PolygonPatch>
-              </polygonPatches>
+              </patches>
             </aixm:Surface>
           </aixm:horizontalProjection>
         </aixm:AirspaceVolume>


### PR DESCRIPTION
GML type "polygonPatches" is a deprecated type. IWXXM XML producers should use GML type "patches" instead. Changes have been validated with NCAR crux utility.